### PR TITLE
Replace reference to ember-cli-ic-ajax with ember-ajax

### DIFF
--- a/_posts/2013-04-03-common-issues.md
+++ b/_posts/2013-04-03-common-issues.md
@@ -83,9 +83,9 @@ Wipe your vendor directory clean then run `npm install && bower install`.
 
 `npm rm ember-data --save-dev`
 
-* To use ember-cli without ic-ajax
+* To use ember-cli without ember-ajax
 
-`npm rm ember-cli-ic-ajax --save-dev`
+`npm rm ember-ajax --save-dev`
 
 * To reinstall latest Ember Data version
 


### PR DESCRIPTION
ember-cli-ic-ajax is no longer in the blueprint for a new app; ember-ajax is.
