### PR TITLE
Overview as introduction

### DIFF
--- a/_posts/2014-04-01-naming-conventions.md
+++ b/_posts/2014-04-01-naming-conventions.md
@@ -6,6 +6,19 @@ category: user-guide
 github: "https://github.com/ember-cli/ember-cli.github.io/blob/master/_posts/2014-04-01-naming-conventions.md"
 ---
 
+
+### Overview
+
+- `kebap-case`
+  - file names
+  - directory names
+  - html tags/ember components
+  - CSS classes
+  - URLs
+- `camelCase`
+  - JavaScript
+  - JSON
+
 When using Ember CLI it's important to keep in mind that the Resolver changes
 some of the naming conventions you would typically use out of the box with Ember,
 Ember Data and Handlebars. In this section we review some of these naming conventions.
@@ -153,18 +166,6 @@ export default Ember.TextField.extend({});
 It is important to keep in mind that the Resolver uses filenames to create
 the associations correctly. This helps you by not having to namespace everything
 yourself. But there are a couple of things you should know.
-
-##### Overview
-
-- Dashes
-  - file names
-  - directory names
-  - html tags/ember components
-  - CSS classes
-  - URLs
-- camelCase
-  - JavaScript
-  - JSON
 
 ##### All filenames should be lowercased
 


### PR DESCRIPTION
The overview is very useful, and I missed it several times until someone helpful on the Ember.js IRC pointed me to it. I suggest placing it as the introduction to fix find-ability, and also changing the keys to be more representative of the naming convention.

From the [Wiki on naming conventions](https://en.wikipedia.org/wiki/Naming_convention_%28programming%29#Multiple-word_identifiers) `kebap-case` is the most common on the still unclear naming conventions of naming conventions (herpederp :P). Wiki says "This convention has no standard name, though it may be referred to as lisp-case or COBOL-CASE (compare Pascal case), kebab-case, or other variants. Of these, kebab-case, dating at least to 2012, has achieved some currency since."
