### PR TITLE
Edit source-maps docs for asset-compilation.md

### DIFF
--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -75,21 +75,22 @@ This would exclude the resulting `vendor.js` file from being minificated.
 
 ### Source Maps
 
-Ember CLI supports producing source maps from your CSS and JS files.
-Source maps are configured by the `sourcemaps` option and
-are disabled in production by default.
+Ember CLI supports producing source maps for your concatenated and minified JS source files. 
 
-In dev, the default setting is equal to:
+Source maps are configured by the EmberApp `sourcemaps` option, and
+are disabled in production by default. Pass `sourcemaps: {enabled: true}` to your EmberApp constructor to enable source maps for javascript. Use the `extensions` option to add other formats, such as coffeescript and CSS: `{extensions: ['js', 'css', 'coffee']}`. JS is supported out-of-the-box. CSS is not currently supported. For other source formats (Sass, Coffee, etc) refer to their addons. 
+
+Default Brocfile.js:
 
 {% highlight bash %}
-sourcemaps: {
-  enabled: true,
-  extensions: ['js']
-}
+import EmberApp from 'ember-cli/lib/broccoli/ember-app';
+var app = new EmberApp({
+  sourcemaps: {
+    enabled: EmberApp.env() !== 'production'
+    extensions: ['js']
+  }
+});
 {% endhighlight %}
-
-Pass `{enabled: true}` to your EmberApp constructor to enable source maps for javascript.
-Use the `extensions` option to configure CSS.
 
 ### Stylesheets
 


### PR DESCRIPTION
This is a duplicate of https://github.com/ember-cli/ember-cli/pull/4167 with some minor style edits. 

The edits are ~7 months old so it's possible source-maps support has moved on. I'm out-of-touch with ember (cli) right now, but hope someone else can assess that.

The original post was:

> As mentioned in #4161 I found the new source maps docs a bit confusing on the website, and expected coffeescript and sass to work out of the box. I've tried not to change a lot, but hopefully it makes it a bit clearer that it isn't that simple :)
> - Mention that other formats depend on their addons
> - Shows how to turn on css
> - Remove "configure" from the css bit, as that suggested there are options somewhere to pass to the subsystem.
> 
> I'm not familiar with the source maps code so suggest someone who knows it quickly checks what I've changed (in particular re: css).

See https://github.com/ember-cli/ember-cli/pull/4167 for discussion.

cc @stefanpenner
