### PR TITLE
fix broken link to test helpers guide

### DIFF
--- a/_posts/2013-04-11-testing.md
+++ b/_posts/2013-04-11-testing.md
@@ -50,7 +50,7 @@ npm install -g phantomjs
 
 #### Using ember-qunit for integration tests
 
-All Ember Apps come with built-in [ember test helpers](http://emberjs.com/guides/testing/test-helpers/),
+All Ember Apps come with built-in [ember test helpers](https://guides.emberjs.com/v2.0.0/testing/acceptance/#toc_test-helpers),
 which are useful for writing integration tests.
 In order to use them, you will need to import `tests/helpers/start-app.js`, which injects the required helpers.
 


### PR DESCRIPTION
The guide to test helpers is on the acceptance testing page now
apparentally. I'm linking directly to the section on the page about test
helpers.
