### PR TITLE
Use correct MIME types for static assets

### DIFF
--- a/_posts/2013-04-04-deployments.md
+++ b/_posts/2013-04-04-deployments.md
@@ -128,6 +128,7 @@ ember build --environment="production"
 
         ## default location ##
         location / {
+            include /etc/nginx/mime.types;
             try_files $uri $uri/ /index.html?/$request_uri;
         }
 


### PR DESCRIPTION
Running nginx 1.9.9, I needed this line to for Google Chrome v48 to actually use the stylesheets, despite the fact Chrome was saying it recoginised the stylesheet being transmitted in text/plain MIME.
