### PR TITLE
Add instruction to put addon in package.json

### DIFF
--- a/_posts/2013-04-06-developing-addons-and-blueprints.md
+++ b/_posts/2013-04-06-developing-addons-and-blueprints.md
@@ -542,9 +542,9 @@ root of your addon project. This will make your addon locally
 available by name.
 
 Then run `npm link <addon-name>` in any hosting application project
-root to make a link to your addon in your `node_modules` directory. Any
-change in your addon will now directly take effect in any project that
-links to it this way (see
+root to make a link to your addon in your `node_modules` directory, and
+add the addon to the `package.json`. Any change in your addon will now 
+directly take effect in any project that links to it this way (see
 [npm-tricks](http://www.devthought.com/2012/02/17/npm-tricks) for more
 details).
 


### PR DESCRIPTION
Added the text "and add the addon to the `package.json`" to the instructions for "Link to addon while developing." This bit me just now, as the package was linked properly but I could not use the addon, getting "Unknown blueprint" when trying to use blueprints from the addon etc... as it was not saved in `package.json`. This change will clarify the process.
