### PR TITLE
Added Windows version of clearing dev folders

### DIFF
--- a/_posts/2013-04-03-upgrading.md
+++ b/_posts/2013-04-03-upgrading.md
@@ -48,25 +48,16 @@ project directory.
     // linux:
     rm -rf node_modules bower_components dist tmp
     
-    // windows powershell - more complicated due to some file-length limits, etc.
+    // windows powershell npm 3
+    rm _blank,tmp,dist,node_modules,bower_components -force -recurse
+    
+    // windows powershell npm 2 - more complicated due to some file-length limits, etc.
     md _blank
     robocopy _blank tmp /purge /nfl /ndl /njh /njs /nc /ns /np > $null
     robocopy _blank dist /purge /nfl /ndl /njh /njs /nc /ns /np > $null
     robocopy _blank node_modules /purge /nfl /ndl /njh /njs /nc /ns /np > $null
     robocopy _blank bower_components /purge /nfl /ndl /njh /njs /nc /ns /np > $null
     rm _blank,tmp,dist,node_modules,bower_components
-    
-    // windows CMD window (DOS-box) - also complicated
-    md _blank
-    robocopy _blank tmp /purge /nfl /ndl /njh /njs /nc /ns /np > nul
-    robocopy _blank dist /purge /nfl /ndl /njh /njs /nc /ns /np > nul
-    robocopy _blank node_modules /purge /nfl /ndl /njh /njs /nc /ns /np > nul
-    robocopy _blank bower_components /purge /nfl /ndl /njh /njs /nc /ns /np > nul
-    rd _blank
-    rd tmp
-    rd dist
-    rd node_modules
-    rd bower_components
     {% endhighlight %}
 
 * Update your project's `package.json` file to use the latest version of

--- a/_posts/2013-04-03-upgrading.md
+++ b/_posts/2013-04-03-upgrading.md
@@ -58,10 +58,10 @@ project directory.
     
     // windows CMD window (DOS-box) - also complicated
     md _blank
-    robocopy _blank tmp /purge /nfl /ndl /njh /njs /nc /ns /np > $null
-    robocopy _blank dist /purge /nfl /ndl /njh /njs /nc /ns /np > $null
-    robocopy _blank node_modules /purge /nfl /ndl /njh /njs /nc /ns /np > $null
-    robocopy _blank bower_components /purge /nfl /ndl /njh /njs /nc /ns /np > $null
+    robocopy _blank tmp /purge /nfl /ndl /njh /njs /nc /ns /np > nul
+    robocopy _blank dist /purge /nfl /ndl /njh /njs /nc /ns /np > nul
+    robocopy _blank node_modules /purge /nfl /ndl /njh /njs /nc /ns /np > nul
+    robocopy _blank bower_components /purge /nfl /ndl /njh /njs /nc /ns /np > nul
     rd _blank
     rd tmp
     rd dist

--- a/_posts/2013-04-03-upgrading.md
+++ b/_posts/2013-04-03-upgrading.md
@@ -42,10 +42,31 @@ project directory.
 
 #### Project Update
 
-* Delete temporary development directories
+* Delete temporary development directories - Windows has some file-path length limits in its rm command so robocopy is needed
 
     {% highlight bash %}
+    // linux:
     rm -rf node_modules bower_components dist tmp
+    
+    // windows powershell - more complicated due to some file-length limits, etc.
+    md _blank
+    robocopy _blank tmp /purge /nfl /ndl /njh /njs /nc /ns /np > $null
+    robocopy _blank dist /purge /nfl /ndl /njh /njs /nc /ns /np > $null
+    robocopy _blank node_modules /purge /nfl /ndl /njh /njs /nc /ns /np > $null
+    robocopy _blank bower_components /purge /nfl /ndl /njh /njs /nc /ns /np > $null
+    rm _blank,tmp,dist,node_modules,bower_components
+    
+    // windows CMD window (DOS-box) - also complicated
+    md _blank
+    robocopy _blank tmp /purge /nfl /ndl /njh /njs /nc /ns /np > $null
+    robocopy _blank dist /purge /nfl /ndl /njh /njs /nc /ns /np > $null
+    robocopy _blank node_modules /purge /nfl /ndl /njh /njs /nc /ns /np > $null
+    robocopy _blank bower_components /purge /nfl /ndl /njh /njs /nc /ns /np > $null
+    rd _blank
+    rd tmp
+    rd dist
+    rd node_modules
+    rd bower_components
     {% endhighlight %}
 
 * Update your project's `package.json` file to use the latest version of
@@ -59,7 +80,7 @@ project directory.
 
     {% highlight bash %}
     npm install
-bower install
+    bower install
     {% endhighlight %}
 
 * Run the new project blueprint on your projects directory. Please follow the

--- a/_posts/2013-04-03-upgrading.md
+++ b/_posts/2013-04-03-upgrading.md
@@ -42,7 +42,8 @@ project directory.
 
 #### Project Update
 
-* Delete temporary development directories - Windows has some file-path length limits in its rm command so robocopy is needed
+* Delete temporary development directories - Windows has some file-path length 
+  limits in its rm command so robocopy is needed if still on npm v2
 
     {% highlight bash %}
     // linux:


### PR DESCRIPTION
Windows rm command cannot remove node_modules and other deep folders - the included commands address this
