### PR TITLE
mocks do not run with ember test, remove language suggesting it does

### DIFF
--- a/_posts/2013-04-12-ember-data.md
+++ b/_posts/2013-04-12-ember-data.md
@@ -100,8 +100,8 @@ appropriate JSON response, you're ready to go. The next time you run
 `ember server`, your new mock server will be listening for any API requests
 from your Ember app.
 
-> Note: Mocks are just for development and testing. The entire `/server`
-directory will be ignored during `ember build`.
+> Note: Mocks are just for development. The entire `/server`
+directory will be ignored during `ember build` and `ember test`.
 
 If you decide to use fixtures instead of mocks, you'll need to use
 `reopenClass` within your model class definitions. First, create a fixture


### PR DESCRIPTION
The language in the guides suggest that http-mocks run with testing, but that's not the case.  testem has it's own http server and the middleware for registering mocks is not used there.

Related to https://github.com/ember-cli/ember-cli/issues/1763
