### PR TITLE
Make the sidebar logo link back to /

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
         <div class="row">
            <div id="sidenav" class="col-md-3 hidden-sm hidden-xs sidebar-wrapper">
             <div class="sidebar">
-              <h1><img src="/assets/images/ember-cli-logo-small-dark.png" alt="Ember CLI" height="40" /></h1>
+              <h1><a href="/"><img src="/assets/images/ember-cli-logo-small-dark.png" alt="Ember CLI" height="40" /></a></h1>
               <ul class="nav sidenav">
                 <li class="ectop"><a href="/">Home</a></li>
                 {% for category in site.categories %}


### PR DESCRIPTION
Makes the logo at the top of the sidebar link to `/`, the same way the "Home" category header does.
For some reason my brain is wired to always try to click on the logo image.

![image](https://cloud.githubusercontent.com/assets/2023/15158817/948b8740-16bf-11e6-80b5-f66286dd66bf.png)
