### PR TITLE
Place command to create addon in the "Create" section

### DIFF
--- a/_posts/2013-04-06-developing-addons-and-blueprints.md
+++ b/_posts/2013-04-06-developing-addons-and-blueprints.md
@@ -53,7 +53,7 @@ Ember CLI has an *addon* command with some options:
 Note: An addon can NOT be created inside an existing application.
 
 ### Create addon
-To create a basic addon:
+To create a basic addon: `ember addon <addon-name>`
 
 Running this command should generate something like the following:
 


### PR DESCRIPTION
- Copies "new" addon command, from "Addon CLI options" - to "Create addon"

Reason: While trying to remember if it was `ember new addon <addon-name>` or `<ember generate addon <addon-name>` or... `ember addon <addon-name>` ~ I was surprised how long it took me to find an answer. This section about "development cycle" starts off with `install` and is generally very confusing (to me).
