### PR TITLE
[FEATURE] - Add link to API from all navigation

### DIFF
--- a/_includes/description.html
+++ b/_includes/description.html
@@ -13,7 +13,7 @@
         <li><a id="viewguide" href="#sidenav">Overview</a></li>
         <li><a href="/user-guide">Guide</a></li>
         <li><a href="/extending">Extend</a></li>
-        <li><a href="https://ember-cli.com/api/" target="_blank">Docs</a></li>
+        <li><a href="https://ember-cli.com/api/" target="_blank">API</a></li>
         <li><a href="https://github.com/ember-cli/ember-cli" target="_blank">Contribute</a></li>
       </ul>
     </div>

--- a/_includes/description.html
+++ b/_includes/description.html
@@ -13,6 +13,7 @@
         <li><a id="viewguide" href="#sidenav">Overview</a></li>
         <li><a href="/user-guide">Guide</a></li>
         <li><a href="/extending">Extend</a></li>
+        <li><a href="https://ember-cli.com/api/" target="_blank">Docs</a></li>
         <li><a href="https://github.com/ember-cli/ember-cli" target="_blank">Contribute</a></li>
       </ul>
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,6 +14,7 @@
         <li><a href="/">Home</a></li>
         <li><a href="/user-guide">Guide</a></li>
         <li><a href="/extending">Extending</a></li>
+        <li><a href="https://ember-cli.com/api/" target="_blank">Docs</a></li>
         <li><a href="https://github.com/ember-cli/ember-cli.github.io" target="_blank">Improve the site</a></li>
       </ul>
     </nav>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
         <li><a href="/">Home</a></li>
         <li><a href="/user-guide">Guide</a></li>
         <li><a href="/extending">Extending</a></li>
-        <li><a href="https://ember-cli.com/api/" target="_blank">Docs</a></li>
+        <li><a href="https://ember-cli.com/api/" target="_blank">API</a></li>
         <li><a href="https://github.com/ember-cli/ember-cli.github.io" target="_blank">Improve the site</a></li>
       </ul>
     </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,6 +32,7 @@
                     {% endfor %}
                   {% endif %}
                 {% endfor %}
+                <li class="ectop"><a href="https://ember-cli.com/api/" target="_blank">Docs</a></li>
                 <li class="ectop"><a href="https://github.com/ember-cli/ember-cli.github.io" target="_blank">Improve the site</a></li>
               </ul>
             </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,7 +32,7 @@
                     {% endfor %}
                   {% endif %}
                 {% endfor %}
-                <li class="ectop"><a href="https://ember-cli.com/api/" target="_blank">Docs</a></li>
+                <li class="ectop"><a href="https://ember-cli.com/api/" target="_blank">API</a></li>
                 <li class="ectop"><a href="https://github.com/ember-cli/ember-cli.github.io" target="_blank">Improve the site</a></li>
               </ul>
             </div>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@ permalink: index.html
                     </a>
                 </li>
                 {% endfor %}
+                <li class="ectop"><a href="https://ember-cli.com/api/" target="_blank">API</a></li>
                 <li class="ectop"><a href="https://github.com/ember-cli/ember-cli.github.io" target="_blank">Improve the site</a></li>
               </ul>
             </div>


### PR DESCRIPTION
I added link to the API docs in the main navigation.  I looked through this entire site and I couldn't find any reference to the API for Ember-CLI.

Main Page Buttons
![image](https://cloud.githubusercontent.com/assets/1489134/17740979/9dfc2b9e-6468-11e6-92c9-a977f419b3dc.png)

SideNav
![image](https://cloud.githubusercontent.com/assets/1489134/17740954/80811d9a-6468-11e6-8aa8-db79754ef00d.png)

Mobile:
![image](https://cloud.githubusercontent.com/assets/1489134/17740961/89f189a0-6468-11e6-82c9-33ab155f001e.png)
