### PR TITLE
Addon publishing `git push` refinement

### DIFF
--- a/_posts/2013-04-06-developing-addons-and-blueprints.md
+++ b/_posts/2013-04-06-developing-addons-and-blueprints.md
@@ -574,8 +574,7 @@ Use *npm* and *git* to publish the addon like a normal npm package.
 
 {% highlight bash %}
 npm version 0.0.1
-git push origin master
-git push origin --tags
+git push origin master --follow-tags
 npm publish
 {% endhighlight %}
 


### PR DESCRIPTION
After some discussion on Ember Slack, @rwjblue pointed out that `--follow-tags` is a better option than `--tags` when `git push`ing. It also only requires one step to push everything.