### PR TITLE
Remove 500px min-height from .guide-content

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -202,7 +202,6 @@ body {
   overflow-x: hidden;
 
   .guide-content {
-    min-height: 500px;
     padding-top: 15px;
     padding-bottom: 40px;
 


### PR DESCRIPTION
The min-height caused some sections with relatively sparse content to include dramatically more space than required; and no section appears strange with the min-height removed.

Before:

<img width="600" alt="before" src="https://cloud.githubusercontent.com/assets/2403023/21312612/1af3c220-c5bb-11e6-8b51-102bfcba72dc.png">

After:

<img width="600" alt="after" src="https://cloud.githubusercontent.com/assets/2403023/21312618/2b1b326e-c5bb-11e6-93f6-d5105f5710ab.png">

All other sections continue to appear as expected.