### PR TITLE
Fix typo and broken list styling in Docker section

### DIFF
--- a/_posts/2013-04-03-common-issues.md
+++ b/_posts/2013-04-03-common-issues.md
@@ -73,7 +73,8 @@ Linux](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide).
 ### Usage with Docker
 
 When building your own [Docker](http://docker.com) image to build Ember
-applications and run tests, there are a copuple of pitfalls to avoid.
+applications and run tests, there are a couple of pitfalls to avoid.
+
 * PhantomJS requires `bzip2` and `fontconfig` to already be installed.
 * After installing PhantomJS, you will need to manually link PhantomJS to
   `/usr/local/bin` if that is not done by the install process.


### PR DESCRIPTION
While github seems to render lists without a leading blank line, that does not work for the built website:
![image](https://cloud.githubusercontent.com/assets/1325249/23176039/b908f862-f861-11e6-85eb-d9462194d7d3.png)
