### PR TITLE
Update configuring output paths.

### DIFF
--- a/_posts/2013-04-09-asset-compilation.md
+++ b/_posts/2013-04-09-asset-compilation.md
@@ -438,8 +438,9 @@ var app = new EmberApp({
 });
 {% endhighlight %}
 
-You may edit any of these output paths, but make sure to update your
-`app.outputPaths.app.html`, default it is `index.html`, and `tests/index.html`.
+You may edit any of these output paths, but make sure to update the paths specified in your
+`app.outputPaths.app.html` default it is `index.html`, and `tests/index.html`. If this is not done,
+your app will not be served with correct asset names.
 
 {% highlight javascript %}
 // ember-cli-build.js


### PR DESCRIPTION
If the `outputPaths` key is used and a user doesn't update the base page with the same names, you end up with a broken app. This wasn't explicitly called out in the guides. Updating the same.

cc: @stefanpenner @rwjblue 