### PR TITLE
Add link to `Asset Compilation` page on `Overview` page

### DIFF
--- a/_posts/2014-04-05-overview.md
+++ b/_posts/2014-04-05-overview.md
@@ -11,7 +11,7 @@ asset pipeline, a strong conventional project structure, and a powerful [addon
 system](http://www.ember-cli.com/extending/#developing-addons-and-blueprints)
 for extension. [Get started.](/user-guide/#getting-started)
 
-Ember CLI has support for:
+Ember CLI's [asset compilation system](https://ember-cli.com/user-guide/#asset-compilation) has support for:
 
 * [Handlebars](http://handlebarsjs.com/)
 * [HTMLBars](https://github.com/tildeio/htmlbars/)


### PR DESCRIPTION
In #111, I caught @martndemus's mention of the fact that the asset compilation page isn't very discoverable from the main docs page. 

This might help 😄.
