### PR TITLE
Thoughts regarding suggested links for 'tutorials'

### DIFF
--- a/_posts/2012-05-01-tutorials.md
+++ b/_posts/2012-05-01-tutorials.md
@@ -7,11 +7,11 @@ github: "https://github.com/ember-cli/ember-cli.github.io/blob/master/_posts/201
 ---
 
 ### Getting Started
-- [Discover Ember (online course)](https://www.ludu.co/course/ember)
-- [ember-cli-101 (book)](http://leanpub.com/ember-cli-101)
-- [Rails + Ember.js (with the Ember CLI)](https://www.devmynd.com/blog/2014-7-rails-ember-js-with-the-ember-cli-redux)
-- [Rock and Roll with EmberJS (book)](http://balinterdi.com/rock-and-roll-with-emberjs/)
-- [Ember.js tutorial](http://yoember.com) (Free, with the latest Ember 2 and Ember CLI)
+- [Official _Ember Guides_ 'Quick Start'](https://guides.emberjs.com/v2.14.0/getting-started/quick-start/)
+- [Official _Ember Guides_ Tutorial](https://guides.emberjs.com/v2.14.0/tutorial/ember-cli/)
+
+### Tooling
+- [Installing Node.js/NPM Without Sudo](http://www.wenincode.com/installing-node-jsnpm-without-sudo)
 
 ### Testing
 - [Creating an Integration Test with Ember.js (Video)](https://www.youtube.com/watch?v=2O24ltr0pPU&feature=youtu.be&list=PLxP_o-ABjKLFuDpuJ2Tw_3__OzxE7kFnh)
@@ -23,9 +23,6 @@ github: "https://github.com/ember-cli/ember-cli.github.io/blob/master/_posts/201
 
 ### Deploying
 - [Lightning Fast Deployments With Rails (in the Wild).](http://blog.abuiles.com/blog/2014/07/08/lightning-fast-deployments-with-rails)
-
-### Tooling
-- [Installing Node.js/NPM Without Sudo](http://www.wenincode.com/installing-node-jsnpm-without-sudo)
 
 ### Example Apps
 - [ember-cli/ember-cli-todos](https://github.com/ember-cli/ember-cli-todos)


### PR DESCRIPTION
There are a great many Ember resources at this point, and the list we have here isn't a fair slice of those. A few of them are not currently up to date + some are _free_ and some are _paid_ - and in general, it seems too random. Are these suggested tutorials for CLI specific things? I think it would be hard to officially recommend Something like rock-and-roll vs mike's front-end-masters courses - let alone the other 12 or so resources / from $0 to $2k. I don't have a solution, but I wanted to bring it up. Either we build an extensive list to use across ember properties / or link to some outside list / or just leave it up to Google.

Either way, the official learning resources should be here. I'm not sure what the best URL is though: https://guides.emberjs.com/v2.14.0/getting-started/quick-start/  vs https://guides.emberjs.com/quick-start and https://guides.emberjs.com/tutorial (it would be great to have a 'latest' URL that was easy to remember)

Thoughts on that?

The only other suggestion is that tooling is moved up in the hierarchy.