### PR TITLE
Update Content Security Policy section

### DIFF
--- a/_posts/2014-04-05-overview.md
+++ b/_posts/2014-04-05-overview.md
@@ -78,16 +78,14 @@ any command-line options whose names must be in camel case form. For example:
 
 ### Content Security Policy
 
-Ember CLI comes bundled with the
-[ember-cli-content-security-policy](https://github.com/rwjblue/ember-cli-content-security-policy/)
-addon which when running the development server, enables [Content Security
-Policy](http://content-security-policy.com/) in modern browsers. When enabled,
-Content Security Policy mitigates certain types of attacks including Cross Site
-Scripting (XSS) and data injection. While [browser
-support](http://caniuse.com/#feat=contentsecuritypolicy) is not yet universal,
-Ember CLI makes it easy to build your app with CSP in mind. For example,
-enabling it on your production stack is as simple as adding these
-[headers](/user-guide/#content-security-policy).
+The [ember-cli-content-security-policy](https://github.com/rwjblue/ember-cli-content-security-policy/)
+addon can be used to to enable the [Content Security Policy](http://content-security-policy.com/) 
+headers in modern browsers when running the development server. When enabled, Content 
+Security Policy headers help mitigate certain types of attacks including Cross Site Scripting (XSS) 
+and data injection. [Browser support](http://caniuse.com/#feat=contentsecuritypolicy) is very good, 
+and Ember CLI + Ember-CLI-Content-Security-Policy addon makes it easy to build your app with CSP in 
+mind. For example, enabling it on your production stack is as simple as adding these
+[headers](/user-guide/#content-security-policy). 
 
 ### Community
 


### PR DESCRIPTION
- Removes reference to plugin being installed by default
- Updates copy to indicate the plugin is how to include CSP headers
- Updates reference to browser support, as it has improved since last update