### PR TITLE
Update 2014-04-03-getting-started.md

### DIFF
--- a/_posts/2014-04-03-getting-started.md
+++ b/_posts/2014-04-03-getting-started.md
@@ -10,7 +10,7 @@ github: "https://github.com/ember-cli/ember-cli.github.io/blob/master/_posts/201
 
 #### Node
 
-First, install the latest version of Node.
+First, install the latest LTS (long-term support) version of Node.
 
 Node is available for a variety of platforms at
 [nodejs.org](http://nodejs.org/). It is important that you _not_ install Node


### PR DESCRIPTION
"Latest" version of node is ambiguous here because there is a "current" and an "LTS" version of node. Adding a note will reduce setup friction in case a user still has 0.10 for some reason.