### PR TITLE
typo fix & small refactoring on subpath development

### DIFF
--- a/_posts/2014-04-03-getting-started.md
+++ b/_posts/2014-04-03-getting-started.md
@@ -230,15 +230,15 @@ the right URL if you've entered the wrong one:
 // index.js
 module.exports = function(app) {
   app.get('/my-app', function(req, res, next) {
-
-    if (req.path != '/my-app/') {
-      res.redirect('/my-app/');
+    let subpath = '/my-app/';
+    if (req.path !== subpath) {
+      res.redirect(subpath);
     } else {
       next();
     }
 
   });
-});
+};
 {% endhighlight %}
 
 Just place it within the `index.js` file of your app's `/server` directory (so that it gets applied when the ember-cli development server is being started). The snippet simply tests if the URL that is being accessed begins with `/my-app/`. And if it doesn't, you'll get redirected. Otherwise, the redirection will be skipped.


### PR DESCRIPTION
- The trailing `)` made the code block's syntax invalid.
- Extracted the subpath as a variable.
- Also used identity comparison rather than equality.