### PR TITLE
Remove DS.FixtureData example from Data section

### DIFF
--- a/_posts/2013-04-12-ember-data.md
+++ b/_posts/2013-04-12-ember-data.md
@@ -74,13 +74,7 @@ export default DS.RESTSerializer.extend({});
 Application-level (default) adapters and serializers should be named
 `adapters/application.js` and `serializers/application.js`, respectively.
 
-### Mocks and fixtures
-
-If you're used to using fixtures to get test data into your app during
-development, you won't be able to create fixture data like you're
-used to doing (i.e. [as specified in the guides](http://emberjs.com/guides/models/the-fixture-adapter/)).
-This is because the models in your Ember CLI app (like all other
-objects) aren't attached to the global namespace.
+### Mocks
 
 Ember CLI comes with an **http-mock** generator which is preferred to
 fixtures for development and testing. Mocks have several advantages
@@ -102,37 +96,3 @@ from your Ember app.
 
 > Note: Mocks are just for development. The entire `/server`
 directory will be ignored during `ember build` and `ember test`.
-
-If you decide to use fixtures instead of mocks, you'll need to use
-`reopenClass` within your model class definitions. First, create a fixture
-adapter, either for a single model or your entire application:
-
-{% highlight javascript %}
-// adapters/application.js
-import DS from "ember-data";
-
-export default DS.FixtureAdapter.extend({});
-{% endhighlight %}
-
-Then add fixture data to your model class:
-
-{% highlight javascript %}
-// models/author.js
-import DS from "ember-data";
-
-var Author = DS.Model.extend({
-  firstName: DS.attr('string'),
-  lastName: DS.attr('string')
-});
-
-Author.reopenClass({
-  FIXTURES: [
-    {id: 1, firstName: 'Bugs', lastName: 'Bunny'},
-    {id: 2, firstName: 'Wile E.', lastName: 'Coyote'}
-  ]
-});
-
-export default Author;
-{% endhighlight %}
-
-Your Ember app's API requests will now use your fixture data.


### PR DESCRIPTION
Ember Data removed support for the FixturesAdapter a couple years ago, see https://github.com/emberjs/data/pull/3717