### PR TITLE
Added to the docs for configs in ember-cli-build

### DIFF
--- a/_posts/2013-04-05-environments.md
+++ b/_posts/2013-04-05-environments.md
@@ -30,6 +30,13 @@ if (ENV.environment === 'development') {
 }
 {% endhighlight %}
 
+You can also import the ENV object in `./ember-cli-build.js` in the event you need environment variables in the build script.
+
+{% highlight javascript %}
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const ENV = require('./config/environment')(EmberApp.env());
+{% endhighlight %}
+
 Ember-CLI assigns `ENV.EmberENV` to `window.EmberENV`, which Ember reads on application initialization.
 
 Additionally, Ember-CLI contains a number of environment-dependent helpers for assets:

--- a/_posts/2013-04-05-environments.md
+++ b/_posts/2013-04-05-environments.md
@@ -30,7 +30,7 @@ if (ENV.environment === 'development') {
 }
 {% endhighlight %}
 
-You can also import the ENV object in `./ember-cli-build.js` in the event you need environment variables in the build script.
+You can also import the ENV object in `./ember-cli-build.js` in case you need environment variables in the build script.
 
 {% highlight javascript %}
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');


### PR DESCRIPTION
Some users might find it useful to access environment variables in the build script. One use case for this is automating what theme.scss file to use based on ENV variable. For white labeling an app across multiple instances.