### PR TITLE
Remove misleading HSTS header in nginx.conf example

### DIFF
--- a/_posts/2013-04-04-deployments.md
+++ b/_posts/2013-04-04-deployments.md
@@ -100,6 +100,9 @@ ember build --environment="production"
         # include information on SSL keys, cert, protocols and ciphers
         # SSLLabs.com is a great resource for this, along with testing
         # your SSL configuration: https://www.ssllabs.com/projects/documentation/
+        
+        # Strict Transport Security
+        add_header Strict-Transport-Security max-age=2592000;
 
         # proxy buffers
         proxy_buffers 16 64k;
@@ -118,7 +121,5 @@ ember build --environment="production"
         listen      80;
         server_name <your-server-name>;
 
-        # Strict Transport Security
-        add_header Strict-Transport-Security max-age=2592000;
         rewrite ^/.*$ https://$host$request_uri? permanent;
     }


### PR DESCRIPTION
According to the MDN docs on HSTS[1], the `Strict-Transport-Security` header is ignored when sent over HTTP because an attacker could have modified it, and so it is redundant in this example.

Moving it to the HTTPS server block means that a user's browser will remember that it should only access the site over HTTPS *after* accessing the site over HTTPS the first time.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#Description