### PR TITLE
Is support still limited to 3 environments?

### DIFF
--- a/_posts/2013-04-05-environments.md
+++ b/_posts/2013-04-05-environments.md
@@ -8,8 +8,8 @@ github: "https://github.com/ember-cli/ember-cli.github.io/blob/master/_posts/201
 
 Ember-CLI ships with support for managing your application's environment.
 Ember-CLI will build an environment config file at `config/environment`. Here,
-you can define an ENV object for each environment (development, test and
-production). For now, this is limited to the three environments mentioned.
+you can define an ENV object for each environment (development, test,
+production, etc.).
 
 The ENV object contains two important keys: 1) EmberENV, and 2) APP. The first
 can be used to define Ember feature flags (see the [Feature Flags


### PR DESCRIPTION
I believe ember-cli can support custom environments beyond development, test, and production so I am eliminating a sentence that states these 3 environments are the only ones that are supported.