### PR TITLE
typo fix - remove a stray letter from the overview

### DIFF
--- a/_posts/2014-04-05-overview.md
+++ b/_posts/2014-04-05-overview.md
@@ -18,7 +18,7 @@ There are thousands of JavaScript libraries that work great in Ember.
 When an npm package offers some Ember-specific conveniences, we call it an "addon."
 Ember CLI’s [addon system](/extending/#developing-addons-and-blueprints)
 provides a way to create reusable units of code, share components and styling, 
-extend the build tooling, and more &mdash; all with a minimal configuration.
+extend the build tooling, and more &mdash; all with minimal configuration.
 To view a complete list of addons, visit 
 [EmberObserver](https://www.emberobserver.com/).
 You can still use your favorite npm packages directly too.


### PR DESCRIPTION
Of course I spot a typo as soon as we merge 😆 . Removes one letter.