### PR TITLE
Deprecation banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 ## EmberCLI's official website <a href="https://ember-community-slackin.herokuapp.com" target="_blank"><img src="https://ember-community-slackin.herokuapp.com/badge.svg"></a>
 
+### Visit the new Ember CLI Guides!
+
+This project is deprecated in favor of [cli-guides](https://github.com/ember-learn/cli-guides), which is an Ember app that hosts most of the content found here in the past. You can see the new site at [cli.emberjs.com](https://cli.emberjs.com).
+
+In the upcoming months, this site will remain up while the redirects and content migrations are being finished.
+
 ### Running with Docker (recommended)
 
 This is the recommended method for new contributors.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## EmberCLI's official website <a href="https://ember-community-slackin.herokuapp.com" target="_blank"><img src="https://ember-community-slackin.herokuapp.com/badge.svg"></a>
+## EmberCLI's official website
 
 ### Visit the new Ember CLI Guides!
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,6 +46,13 @@
                     <span class="glyphicon glyphicon-pencil"></span>
                   </a>
                   <h1>{{guide.title}}</h1>
+                  <div class="deprecation-banner row">
+                    The Ember CLI Guides have moved! Please visit
+                    <a href="https://cli.emberjs.com">
+                      cli.emberjs.com
+                    </a>
+                    instead for the most up-to-date content. 
+                  </div>
                   <p>{{guide.content}}</p>
                 </div>
                 {% endif %}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -368,6 +368,14 @@ body {
 
 }
 
+.deprecation-banner.row {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  font-size: 1.5em;
+  background-color: #ffefcc;
+  padding: 20px;
+}
+
 .highlight .lineno {
   display: none;
 }


### PR DESCRIPTION
This PR adds a deprecation banner below each title section. It does not attempt to link to the specific section.

In the next few weeks, we'll implement the final pieces of content that are missing in the new guides, plus redirects for all the links present in the currently hosted app.

Feedback welcome! I don't love how it looks.

![screen shot 2018-11-26 at 12 02 52 am](https://user-images.githubusercontent.com/16627268/48994084-489f4100-f10f-11e8-95b5-0a6600ed7f98.png)