### PR TITLE
Provide link to discord in Community links

### DIFF
--- a/_posts/2014-04-05-overview.md
+++ b/_posts/2014-04-05-overview.md
@@ -101,7 +101,7 @@ improve your quality of life as an Ember developer.
 
 Talk to us here:
 
-* Slack: [Get your invite](https://ember-community-slackin.herokuapp.com)
+* Discord: [Get your invite](https://discordapp.com/invite/zT3asNS)
 * Issues: [ember-cli/issues](https://github.com/ember-cli/ember-cli/issues)
 
 ### Node


### PR DESCRIPTION
The page linked to Slack.  Our current platform for communication is Discord.

@locks Here you go