### PR TITLE
Remove CNAME configuration file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-ember-cli.com


### PR DESCRIPTION
This PR removes CNAME file in hope re-enabling access to other repositories Github pages under Ember CLI organisation. 🤞 

Example: 

https://ember-cli.github.io/ember-exam/ (https://github.com/ember-cli/ember-exam)

--

_This repository might need additional configuration in Settings._